### PR TITLE
fix: invalid pipelineRuns selector

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -402,9 +402,6 @@ func (c *Controller) getPipelineRunsWithSelector(context, namespace, selector st
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pipelineruns with label %s", label.String())
 	}
-	if len(runs) > 1 {
-		return nil, fmt.Errorf("%s pipelineruns found with label %s, expected only 1", string(len(runs)), label.String())
-	}
 	if len(runs) == 0 {
 		return nil, apierrors.NewNotFound(pipelinev1alpha1.Resource("pipelinerun"), label.String())
 	}
@@ -532,20 +529,20 @@ func reconcile(c reconciler, key string) error {
 		if err != nil {
 			return fmt.Errorf("no pipelinerun found with name %s: %v", name, err)
 		}
-		prowJobName := p.Labels[prowJobName]
-		if prowJobName == "" {
+		jobName := p.Labels[prowJobName]
+		if jobName == "" {
 			return fmt.Errorf("no prowjob name label for pipelinerun %s: %v", name, err)
 		}
 
-		pj, err = c.getProwJob(prowJobName)
+		pj, err = c.getProwJob(jobName)
 		if err != nil {
 			return fmt.Errorf("no matching prowjob for pipelinerun %s: %v", name, err)
 		}
 
-		selector := fmt.Sprintf("%s = %s", prowJobName, name)
+		selector := fmt.Sprintf("%s = %s", prowJobName, jobName)
 		runs, err = c.getPipelineRunsWithSelector(ctx, namespace, selector)
 		if err != nil {
-			return fmt.Errorf("get pipelineruns %s by prow job %s: %v", key, prowJobName, err)
+			return fmt.Errorf("get pipelineruns %s by prow job %s: %v", key, jobName, err)
 		}
 		havePipelineRun = true
 


### PR DESCRIPTION
This PR fixes a pretty obvious bug: the pipelineRuns selector was totally wrong, partially due to a constant being overridden.

On my cluster, the consequences of that were pipelines restarting indefinitely, until the corresponding prowJob was manually deleted.

In the logs, I could read many such lines
```
E1223 08:44:02.246500       1 controller.go:281] failed to reconcile default/jx/04394ba7-4428-11eb-8be1-0a4fdab0cd08/ProwJob: finding pipeline "meta-olli-ai-environment-jenkin-q62rw-1222": pipelinerun.tekton.dev "meta-olli-ai-environment-jenkin-q62rw-1222" not found
```

Those were not the direct consequences of the bug, but more a consequence of the controller malfunction, and would trigger another pipeline to start for the same prowJob.
My guess is that, once a pipeline was finished, the controller couldn't find the corresponding prowJob, and thus its status would never be updated.

Signed-off-by: Aurélien Lambert <aure@olli-ai.com>